### PR TITLE
Fix bug in OrdinalCategoricalBucketer with encoding_method set to 'ordered'

### DIFF
--- a/skorecard/bucketers/bucketers.py
+++ b/skorecard/bucketers/bucketers.py
@@ -989,7 +989,7 @@ class OrdinalCategoricalBucketer(BaseBucketer):
 
         Args:
             tol (float): the minimum frequency a label should have to be considered frequent.
-                Categories with frequencies lower than tol will be grouped together (in the highest ).
+                Categories with frequencies lower than tol will be grouped together (in the 'other' bucket).
             max_n_categories (int): the maximum number of categories that should be considered frequent.
                 If None, all categories with frequency above the tolerance (tol) will be
                 considered.
@@ -1070,9 +1070,10 @@ class OrdinalCategoricalBucketer(BaseBucketer):
             if self.encoding_method == "ordered":
                 if y is None:
                     raise ValueError("To use encoding_method=='ordered', y cannot be None.")
+
                 # X_flt["target"] = y_flt
                 normalized_counts = X_y[var].value_counts(normalize=True)
-                cats = X_y.groupby([var])["target"].mean().sort_values(ascending=True).index
+                cats = X_y.groupby([var])["target"].mean().sort_values(ascending=False).index
                 normalized_counts = normalized_counts[cats]
 
             if self.encoding_method == "frequency":
@@ -1080,7 +1081,6 @@ class OrdinalCategoricalBucketer(BaseBucketer):
 
             # Limit number of categories if set.
             normalized_counts = normalized_counts[: self.max_n_categories]
-
             # Remove less frequent categories
             normalized_counts = normalized_counts[normalized_counts >= self.tol]
 

--- a/tests/test_bucketer_OrdinalCategoricalBucketer.py
+++ b/tests/test_bucketer_OrdinalCategoricalBucketer.py
@@ -58,12 +58,12 @@ def test_encoding_method(df):
     ocb = OrdinalCategoricalBucketer(tol=0.03, variables=["EDUCATION"], encoding_method="frequency")
     ocb.fit(X, y)
 
-    assert ocb.features_bucket_mapping_.get("EDUCATION").map == {2: 0, 1: 1, 3: 2}
+    assert ocb.features_bucket_mapping_.get("EDUCATION").map == {1: 1, 2: 0, 3: 2}
 
     ocb = OrdinalCategoricalBucketer(tol=0.03, variables=["EDUCATION"], encoding_method="ordered")
     ocb.fit(X, y)
 
-    assert ocb.features_bucket_mapping_.get("EDUCATION").map == {1: 0, 3: 1, 2: 2}
+    assert ocb.features_bucket_mapping_.get("EDUCATION").map == {1: 2, 2: 0, 3: 1}
 
 
 def test_specials(df):


### PR DESCRIPTION
closes #8 