### PR TITLE
Fit interactive for pipelines

### DIFF
--- a/docs/tutorials/interactive_bucketing.ipynb
+++ b/docs/tutorials/interactive_bucketing.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 12,
    "source": [
     "from skorecard.datasets import load_uci_credit_card\n",
     "from skorecard.bucketers import DecisionTreeBucketer\n",
@@ -38,6 +38,35 @@
     "\n",
     "![dash app example](../assets/img/dash_app_numerical_bucketer.png)"
    ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Pipelines\n",
+    "\n"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "source": [
+    "from skorecard.bucketers import OrdinalCategoricalBucketer\n",
+    "from skorecard.pipeline import to_skorecard_pipeline\n",
+    "from sklearn.pipeline import make_pipeline\n",
+    "\n",
+    "pipe = make_pipeline(\n",
+    "    OrdinalCategoricalBucketer(variables=[\"EDUCATION\",\"MARRIAGE\"]),\n",
+    "    DecisionTreeBucketer(max_n_bins=10, variables=[\"LIMIT_BAL\",\"BILL_AMT1\"])\n",
+    ")\n",
+    "\n",
+    "# Make this a skorecard pipeline, which adds some convenience methods\n",
+    "pipe = to_skorecard_pipeline(pipe)\n",
+    "\n",
+    "# pipe.fit_interactive(X, y) # not run\n"
+   ],
+   "outputs": [],
    "metadata": {}
   }
  ],

--- a/docs/tutorials/interactive_bucketing.ipynb
+++ b/docs/tutorials/interactive_bucketing.ipynb
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 39,
    "source": [
     "from skorecard.bucketers import OrdinalCategoricalBucketer\n",
     "from skorecard.pipeline import to_skorecard_pipeline\n",
@@ -64,8 +64,23 @@
     "# Make this a skorecard pipeline, which adds some convenience methods\n",
     "pipe = to_skorecard_pipeline(pipe)\n",
     "\n",
-    "# pipe.fit_interactive(X, y) # not run\n"
+    "pipe.fit_interactive(X, y) # not run\n"
    ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Dash app running on http://127.0.0.1:8050/\n"
+     ]
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [],
    "outputs": [],
    "metadata": {}
   }

--- a/skorecard/apps/app_callbacks.py
+++ b/skorecard/apps/app_callbacks.py
@@ -120,10 +120,11 @@ def add_bucketing_callbacks(self, X, y):
         # Update the fit for this specific column
         special = self.features_bucket_mapping_.get(col).specials
         right = self.features_bucket_mapping_.get(col).right
-        # Note we passed X, y to add_bucketing_callbacks()
-        self._update_column_fit(X, y, col, special, input_map, right)
+        # Note we passed X, y to add_bucketing_callbacks() so they are available here.
         # make sure to re-generate the summary table
-        self._generate_summary(X, y)
+        self._update_column_fit(
+            X=X, y=y, feature=col, special=special, splits=input_map, right=right, generate_summary=True
+        )
 
         # Retrieve the new bucket tables and plots
         table = self.bucket_table(col)
@@ -145,7 +146,8 @@ def add_bucketing_callbacks(self, X, y):
         col_type = self.features_bucket_mapping_.get(col).type
 
         if col_type == "categorical":
-            str_repr = json.dumps(input_map, indent=4)
+            str_repr = ",\n\t".join([f"{k}: {v}" for k, v in input_map.items()])
+            str_repr = f"{{\n\t{str_repr}\n}}"
         else:
             str_repr = str(input_map)
         return [str_repr]

--- a/skorecard/apps/app_callbacks.py
+++ b/skorecard/apps/app_callbacks.py
@@ -66,14 +66,18 @@ def add_bucketing_callbacks(self, X, y):
     app = self.app
 
     @app.callback(
-        [Output("column_title", "children")],
+        [
+            Output("column_title", "children"),
+            Output("column_type", "children"),
+        ],
         [
             Input("input_column", "value"),
         ],
     )
-    def update_column_title(title):
+    def update_column_title(col):
         """Update the content title."""
-        return [f"Feature '{title}'"]
+        col_type = self.features_bucket_mapping_.get(col).type
+        return [f"Feature '{col}'"], [col_type]
 
     @app.callback(
         [

--- a/skorecard/apps/app_layout.py
+++ b/skorecard/apps/app_layout.py
@@ -98,7 +98,13 @@ def add_basic_layout(self):
         children=[
             dbc.Row(
                 [
-                    html.H3("Current column", id="column_title", style=TEXT_STYLE),
+                    html.H3(
+                        [
+                            html.Span("Current column", id="column_title"),
+                            dbc.Badge("tbd", id="column_type", className="ml-1"),
+                        ],
+                        style=TEXT_STYLE,
+                    ),
                 ]
             ),
             html.Br(),

--- a/skorecard/bucketers/base_bucketer.py
+++ b/skorecard/bucketers/base_bucketer.py
@@ -244,7 +244,7 @@ class BaseBucketer(BaseEstimator, TransformerMixin, PlotBucketMethod, BucketTabl
 
         return self
 
-    def _update_column_fit(self, X, y, feature, special, splits, right):
+    def _update_column_fit(self, X, y, feature, special, splits, right, generate_summary=False):
         """
         Extract out part of the fit for a column.
 
@@ -309,6 +309,9 @@ class BaseBucketer(BaseEstimator, TransformerMixin, PlotBucketMethod, BucketTabl
                 column=feature,
                 bucket_mapping=self.features_bucket_mapping_.get(feature),
             )
+
+        if generate_summary:
+            self._generate_summary(X, y)
 
     def fit_interactive(self, X, y=None, mode="external"):
         """

--- a/skorecard/pipeline/pipeline.py
+++ b/skorecard/pipeline/pipeline.py
@@ -11,7 +11,18 @@ from sklearn.utils.validation import check_is_fitted
 from skorecard.features_bucket_mapping import FeaturesBucketMapping
 from skorecard.reporting.plotting import PlotBucketMethod
 from skorecard.reporting.report import BucketTableMethod, SummaryMethod
-from skorecard.utils import BucketingPipelineError, NotBucketObjectError
+from skorecard.utils import BucketingPipelineError, NotBucketObjectError, NotInstalledError
+from skorecard.utils.validation import is_fitted
+
+# JupyterDash
+try:
+    from jupyter_dash import JupyterDash
+except ModuleNotFoundError:
+    JupyterDash = NotInstalledError("jupyter-dash", "dashboard")
+
+
+from skorecard.apps.app_layout import add_basic_layout
+from skorecard.apps.app_callbacks import add_bucketing_callbacks
 
 
 class KeepPandas(BaseEstimator, TransformerMixin):
@@ -227,6 +238,7 @@ class SkorecardPipeline(Pipeline, PlotBucketMethod, BucketTableMethod, SummaryMe
     - `.bucket_table()`: Table with buckets of a column
     - `.save_to_yaml()`: Save information necessary for bucketing to a YAML file
     - `.features_bucket_mapping_`: Access bucketing information
+    - `.fit_interactive()`: Edit fitted buckets interactively in a dash app
 
     ```python
     from skorecard.pipeline.pipeline import SkorecardPipeline
@@ -340,6 +352,56 @@ class SkorecardPipeline(Pipeline, PlotBucketMethod, BucketTableMethod, SummaryMe
                 msg = "All bucketing steps must be skorecard bucketers."
                 msg += f"Remove {step} from the pipeline."
                 raise NotBucketObjectError(msg)
+
+    @property
+    def variables(self):
+        """
+        Helper function to show which features are in scope of this pipeline.
+        """
+        return self.features_bucket_mapping_.columns
+
+    def fit_interactive(self, X, y=None, mode="external"):
+        """
+        Fit a bucketer and then interactive edit the fit using a dash app.
+
+        Note we are using a [jupyterdash](https://medium.com/plotly/introducing-jupyterdash-811f1f57c02e) app,
+        which supports 3 different modes:
+
+        - 'external' (default): Start dash server and print URL
+        - 'inline': Start dash app inside an Iframe in the jupyter notebook
+        - 'jupyterlab': Start dash app as a new tab inside jupyterlab
+
+        """
+        # We need to make sure we only fit if not already fitted
+        # This prevents a user loosing manually defined boundaries
+        # when re-running .fit_interactive()
+        if not is_fitted(self):
+            self.fit(X, y)
+
+        import dash_bootstrap_components as dbc
+
+        self.app = JupyterDash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+        add_basic_layout(self)
+        add_bucketing_callbacks(self, X, y)
+        self.app.run_server(mode=mode)
+
+    def _update_column_fit(self, X, y, feature, special, splits, right, generate_summary=False):
+        """
+        Extract out part of the fit for a column.
+
+        Useful when we want to interactively update the fit.
+        """
+        for step in self.steps:
+            if feature in step[1].variables:
+                step[1]._update_column_fit(
+                    X=X,
+                    y=y,
+                    feature=feature,
+                    special=special,
+                    splits=splits,
+                    right=right,
+                    generate_summary=generate_summary,
+                )
 
 
 def to_skorecard_pipeline(pipeline: Pipeline) -> SkorecardPipeline:


### PR DESCRIPTION
This PR adds support for:

- `SkorecardPipeline.fit_interactive()`
- Showing feature type in the dash app (categorical or numerical)

What's still missing? 

- support for setting missing_bucket or other_bucket
- support for `.fit_interactive()` for `BucketingProcess()` and `Skorecard()`

Code example:

```python
from skorecard.datasets import load_uci_credit_card
from skorecard.bucketers import DecisionTreeBucketer, OrdinalCategoricalBucketer
from skorecard.pipeline import to_skorecard_pipeline
from sklearn.pipeline import make_pipeline

X, y = load_uci_credit_card(return_X_y=True)

pipe = make_pipeline(
    OrdinalCategoricalBucketer(variables=["EDUCATION","MARRIAGE"]),
    DecisionTreeBucketer(max_n_bins=10, variables=["LIMIT_BAL","BILL_AMT1"])
)

# Make this a skorecard pipeline, which adds some convenience methods
pipe = to_skorecard_pipeline(pipe)

pipe.fit_interactive(X, y) # not run
```

Screenshot:

![image](https://user-images.githubusercontent.com/5570380/129220477-9fd5ab80-377d-40c0-83e5-d1ac2a860278.png)
