### PR TITLE
Modified bucket_table() to compute WoE consistent with category_encoder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       entry: black
       language: python_venv
       types: [python]
-      language_version: python3.8
+      language_version: python3
       args: [--line-length=120]
   - repo: local
     hooks:

--- a/skorecard/reporting/report.py
+++ b/skorecard/reporting/report.py
@@ -126,6 +126,7 @@ def build_bucket_table(
     event_percentage = (stats["Event"] + epsilon) / (stats["Event"].sum() + 2 * epsilon)
     non_event_percentage = (stats["Non-event"] + epsilon) / (stats["Non-event"].sum() + 2 * epsilon)
     stats["WoE"] = (event_percentage / non_event_percentage).apply(lambda x: np.log(x))
+    stats.loc[stats["Count"] == 0, "WoE"] = np.nan
 
     stats["IV"] = (stats["% Non-event"] - stats["% Event"]) * stats["WoE"]
 

--- a/tests/test_bucket_table_woe_values.py
+++ b/tests/test_bucket_table_woe_values.py
@@ -1,0 +1,22 @@
+import pandas as pd
+import numpy as np
+
+from skorecard.datasets import load_uci_credit_card
+from skorecard import Skorecard
+
+
+def test_bucket_table_woe_values():
+    """Checks whether or not the WoE-values of bucket_table()are equivalent to those in the transformed data."""
+    data = load_uci_credit_card()
+    X = data["data"]
+    y = data["target"]
+
+    model = Skorecard()
+    model = model.fit(X, y)
+    X_woe = model.woe_transform(X)
+    for c in X.columns:
+        bucket_table = model.bucket_table(c)
+        b_tab_woes = set(bucket_table["WoE"])
+        b_tab_woes = {x for x in b_tab_woes if pd.notna(x)}
+        data_woes = set(np.round(X_woe[c].value_counts().index, 3))
+        assert b_tab_woes == data_woes


### PR DESCRIPTION
#87 
Hard-coded WoE calculation in bucket_table to be consistent with the category_encoder  (v2.5.1) implementation of WoE. 

A direct call on the WOEEncoder object might be preferable, but seems inconvenient given the currrent code setup. 