### PR TITLE
Suppressor

### DIFF
--- a/skorecard/skorecard.py
+++ b/skorecard/skorecard.py
@@ -8,7 +8,7 @@ from category_encoders.woe import WOEEncoder
 
 from skorecard.linear_model import LogisticRegression
 from skorecard.utils import BucketerTypeError
-from skorecard.utils.validation import ensure_dataframe, is_fitted
+from skorecard.utils.validation import ensure_dataframe, is_fitted, check_suppressor_effect
 from skorecard.pipeline import BucketingProcess, to_skorecard_pipeline
 from skorecard.pipeline.pipeline import _get_all_steps
 from skorecard.bucketers import (
@@ -205,8 +205,10 @@ class Skorecard(BaseEstimator, ClassifierMixin):
         bucketing_pipeline = to_skorecard_pipeline(make_pipeline(*bucketing_pipe))
 
         return BucketingProcess(
-            specials=self.specials, prebucketing_pipeline=prebucketing_pipeline, bucketing_pipeline=bucketing_pipeline,
-            random_state=self.random_state
+            specials=self.specials,
+            prebucketing_pipeline=prebucketing_pipeline,
+            bucketing_pipeline=bucketing_pipeline,
+            random_state=self.random_state,
         )
 
     def _build_pipeline(self, X):
@@ -275,6 +277,8 @@ class Skorecard(BaseEstimator, ClassifierMixin):
         # Save some stuff for scikitlearn
         self.coef_ = self.pipeline_[-1].coef_
         self.n_features_in_ = len(X.columns)
+
+        check_suppressor_effect(self.coef_[0], X.columns)
 
         return self
 

--- a/skorecard/utils/validation.py
+++ b/skorecard/utils/validation.py
@@ -58,3 +58,15 @@ def check_args(args: Dict, obj):
         if arg not in valid_args:
             msg = f"Argument '{arg}' is not a valid argument for object '{obj}'"
             warnings.warn(msg)
+
+
+def check_suppressor_effect(coefs: list, feat_names: list):
+    """Checks if the coefficients all have the expected sign."""
+    suspect_feats = []
+    for i, c in enumerate(coefs):
+        if c < 0:
+            suspect_feats.append(feat_names[i])
+    if len(suspect_feats) != 0:
+        msg = f"Features found with coefficient-sign that is contrary to what is expected based on weight-of-evidence. \
+                This is likely caused by multi-collinearity. The features are: {suspect_feats}"
+        warnings.warn(msg)

--- a/tests/test_suppressor_warning.py
+++ b/tests/test_suppressor_warning.py
@@ -1,0 +1,45 @@
+import warnings
+
+from skorecard.datasets import load_uci_credit_card
+from skorecard import Skorecard
+
+
+def test_suppressor_warning():
+    """Checks suppressor effect warning on Skorecard fit."""
+    # Load the data. Construct datasets with and without suppressor effect occurring
+    data = load_uci_credit_card()
+    y = data["target"]
+
+    X_no_suppression = data["data"]
+    model = Skorecard()
+
+    X_suppression = X_no_suppression.copy()
+    X_suppression["suppressor"] = X_suppression[X_suppression.columns[0]] - X_suppression[X_suppression.columns[1]]
+    model_suppression = Skorecard()
+
+    with warnings.catch_warnings(record=True) as w:
+        # Check that the suppressor warning is not issued and that no coefficient has an unexpected sign
+        model = model.fit(X_no_suppression, y)
+        relevant_warning_issued = 0
+        if len(w) > 0:
+            latest_warning = str(w[-1].message)
+            msg = (
+                "Features found with coefficient-sign that is contrary to what is expected based on weight-of-evidence."
+            )
+            relevant_warning_issued = msg in latest_warning
+        coefs = model.coef_[0]
+        suppression = any(c < 0 for c in coefs)
+        assert (not relevant_warning_issued) & (not suppression)
+
+        # Check that the suppressor warning is issued and that there is a coefficient with an unexpected sign
+        model_suppression = model_suppression.fit(X_suppression, y)
+        relevant_warning_issued = 0
+        if len(w) > 0:
+            latest_warning = str(w[-1].message)
+            msg = (
+                "Features found with coefficient-sign that is contrary to what is expected based on weight-of-evidence."
+            )
+            relevant_warning_issued = msg in latest_warning
+        coefs = model_suppression.coef_[0]
+        suppression = any(c < 0 for c in coefs)
+        assert (relevant_warning_issued) & (suppression)


### PR DESCRIPTION
Fix for #85:
The Skorecard() fit method now issues a warning in case there is a coefficient with an unexpected (i.e., negative) sign. 

Note that coefficients are always expected to be positive when bucketing and WoE-encoding variables, since the conventions used for WoE are such that higher WoE implies higher predicted probability of target.  