### PR TITLE
fix selection of best categories bucketers.py

### DIFF
--- a/skorecard/bucketers/bucketers.py
+++ b/skorecard/bucketers/bucketers.py
@@ -811,7 +811,7 @@ class OrdinalCategoricalBucketer(BaseBucketer):
             normalized_counts = X_y[feature].value_counts(normalize=True)
 
         # Limit number of categories if set.
-        normalized_counts = normalized_counts[: self.max_n_categories]
+        normalized_counts = normalized_counts[-self.max_n_categories:]
         # Remove less frequent categories
         normalized_counts = normalized_counts[normalized_counts >= self.tol]
 


### PR DESCRIPTION
Currently, when encoding_method == "ordered" the features are ordered based on the proportion of events in the target variable in ascending order.

Ideally, we would like to keep the categories with highest proportion of events separately, and those with lowest volume of events, then to be dropped

by doing 

normalized_counts = normalized_counts[-self.max_n_categories:]

we ensure to keep the top frequent categories